### PR TITLE
Add plotting of origin uncertainties in web gis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_install:
   - conda create --yes -n condaenv python=$TRAVIS_PYTHON_VERSION
   - conda install --yes -n condaenv pip
   - source activate condaenv
-  - conda install --yes -c conda-forge obspy psycopg2 markdown flake8 gdal pyyaml pip
+  - conda install --yes -c conda-forge obspy psycopg2 markdown flake8 gdal pyyaml pip geopy
   - pip install codecov "django>=1.9,<1.10" djangorestframework djangorestframework-gis djangorestframework-jsonp djangorestframework-xml djangorestframework-yaml django-cors-headers django-debug-toolbar django-plugins defusedxml geojson markdown mkdocs mkdocs-bootswatch
   # Copy local_settings template.
   - cp $TRAVIS_BUILD_DIR/src/jane/local_settings.py.example $TRAVIS_BUILD_DIR/src/jane/local_settings.py

--- a/docs/docs/setup.md
+++ b/docs/docs/setup.md
@@ -31,6 +31,7 @@ with the following Python modules
 * `flake8`
 * `gdal`  ([see here for Windows](http://www.lfd.uci.edu/~gohlke/pythonlibs/#gdal))
 * `geojson`
+* `geopy`
 * `markdown`
 * `mkdocs`
 * `mkdocs-bootswatch`
@@ -46,7 +47,7 @@ used to setup a new dedicated and separate environment to run `Jane`:
 $ conda config --add channels obspy
 $ conda create -n jane python=3.5
 $ source activate jane
-(jane)$ conda install obspy psycopg2 markdown flake8 gdal pyyaml pip
+(jane)$ conda install obspy psycopg2 markdown flake8 gdal pyyaml pip geopy
 # Install the latest 1.9.x release.
 (jane)$ pip install "django>=1.9,<1.10"
 (jane)$ pip install djangorestframework djangorestframework-gis djangorestframework-jsonp djangorestframework-xml djangorestframework-yaml django-cors-headers django-debug-toolbar django-plugins defusedxml geojson markdown mkdocs mkdocs-bootswatch
@@ -63,6 +64,7 @@ dependencies:
 - markdown
 - flake8
 - gdal
+- geopy
 - pyyaml
 - pip
 - pip:
@@ -239,6 +241,7 @@ apt-get install python3-psycopg2 \
     python3-yaml \
     python3-defusedxml \
     python3-gdal \
+    python3-geopy \
     python3-flake8 \
     python3-pip \
     python3-obspy \

--- a/src/jane/quakeml/plugins.py
+++ b/src/jane/quakeml/plugins.py
@@ -219,6 +219,7 @@ class QuakeMLIndexerPlugin(IndexerPluginPoint):
                         end2 = distance.destination(
                             point=start, bearing=azimuth + 180)
                         line = LineString((end1.longitude, end1.latitude),
+                                          (org.longitude, org.latitude),
                                           (end2.longitude, end2.latitude))
                         lines.append(line)
                     geometry.append(MultiLineString(lines))

--- a/src/jane/quakeml/plugins.py
+++ b/src/jane/quakeml/plugins.py
@@ -116,6 +116,9 @@ class QuakeMLIndexerPlugin(IndexerPluginPoint):
         "event_type": "str",
         "has_focal_mechanism": "bool",
         "has_moment_tensor": "bool",
+        "horizontal_uncertainty_max": "float",
+        "horizontal_uncertainty_min": "float",
+        "horizontal_uncertainty_max_azimuth": "float",
     }
 
     def index(self, document):
@@ -124,7 +127,8 @@ class QuakeMLIndexerPlugin(IndexerPluginPoint):
 
         :param document: The document as a memory file.
         """
-        from django.contrib.gis.geos.point import Point  # NOQA
+        from django.contrib.gis.geos import (
+            Point, LineString, MultiLineString)
         from obspy import read_events
 
         # Collect all indices in a list. Each index has to be a dictionary.
@@ -168,6 +172,58 @@ class QuakeMLIndexerPlugin(IndexerPluginPoint):
                 evaluation_mode = extra["evaluationMode"]["value"]
             else:
                 evaluation_mode = None
+            # parse horizontal uncertainties
+            if org and org.origin_uncertainty:
+                org_unc = org.origin_uncertainty
+                if org_unc.preferred_description == 'horizontal uncertainty':
+                    horizontal_uncertainty_max = org_unc.horizontal_uncertainty
+                    horizontal_uncertainty_min = org_unc.horizontal_uncertainty
+                    horizontal_uncertainty_max_azimuth = 0
+                elif org_unc.preferred_description == 'uncertainty ellipse':
+                    horizontal_uncertainty_max = \
+                        org_unc.max_horizontal_uncertainty
+                    horizontal_uncertainty_min = \
+                        org_unc.min_horizontal_uncertainty
+                    horizontal_uncertainty_max_azimuth = \
+                        org_unc.azimuth_max_horizontal_uncertainty
+                else:
+                    horizontal_uncertainty_max = None
+                    horizontal_uncertainty_min = None
+                    horizontal_uncertainty_max_azimuth = None
+            else:
+                horizontal_uncertainty_max = None
+                horizontal_uncertainty_min = None
+                horizontal_uncertainty_max_azimuth = None
+
+            geometry = None
+            if org:
+                geometry = [Point(org.longitude, org.latitude)]
+                if all(value is not None for value in (
+                        horizontal_uncertainty_max, horizontal_uncertainty_min,
+                        horizontal_uncertainty_max_azimuth)):
+                    import geopy
+                    import geopy.distance
+                    start = geopy.Point(latitude=org.latitude,
+                                        longitude=org.longitude)
+                    lines = []
+                    for distance, azimuth in (
+                            (horizontal_uncertainty_max,
+                             horizontal_uncertainty_max_azimuth),
+                            (horizontal_uncertainty_min,
+                             horizontal_uncertainty_max_azimuth + 90)):
+                        azimuth = azimuth % 180
+                        distance = geopy.distance.VincentyDistance(
+                            kilometers=distance / 1e3)
+                        end1 = distance.destination(
+                            point=start, bearing=azimuth)
+                        end2 = distance.destination(
+                            point=start, bearing=azimuth + 180)
+                        line = LineString((end1.longitude, end1.latitude),
+                                          (end2.longitude, end2.latitude))
+                        lines.append(line)
+                    geometry.append(MultiLineString(lines))
+                else:
+                    geometry.append(MultiLineString([]))
 
             indices.append({
                 "quakeml_id": str(event.resource_id),
@@ -189,8 +245,11 @@ class QuakeMLIndexerPlugin(IndexerPluginPoint):
                 # The special key geometry can be used to store geographic
                 # information about the indexes geometry. Useful for very
                 # fast queries using PostGIS.
-                "geometry":
-                    [Point(org.longitude, org.latitude)] if org else None,
+                "geometry": geometry,
+                "horizontal_uncertainty_max": horizontal_uncertainty_max,
+                "horizontal_uncertainty_min": horizontal_uncertainty_min,
+                "horizontal_uncertainty_max_azimuth":
+                    horizontal_uncertainty_max_azimuth,
             })
 
         return indices

--- a/src/jane/static/web_gis/index.html
+++ b/src/jane/static/web_gis/index.html
@@ -194,7 +194,7 @@
         </div>
 
         <div class="row">
-            <div class="col-md-2">
+            <div class="col-md-4">
                 <label>
                     <small>
                         Status
@@ -219,6 +219,23 @@
                 <toggle-switch model="event_settings.show_automatic_and_manual"
                                class="switch-mini switch-default"
                                on-label="all" off-label="manual"
+                               style="width:100%">
+                </toggle-switch>
+            </div>
+        </div>
+
+        <div class="row">
+            <div class="col-md-4">
+                <label>
+                    <small>
+                        Show uncertainties?
+                    </small>
+                </label>
+            </div>
+            <div class="col-md-4">
+                <toggle-switch model="event_settings.show_uncertainties"
+                               class="switch-mini switch-default"
+                               on-label="on" off-label="off"
                                style="width:100%">
                 </toggle-switch>
             </div>

--- a/src/jane/static/web_gis/src/baynetapp.js
+++ b/src/jane/static/web_gis/src/baynetapp.js
@@ -72,16 +72,20 @@ module.factory('events', function($http, $log, jane_server) {
                         j.attachments = i.attachments;
                         j.containing_document_data_url = i.containing_document_data_url;
                         // Now create GeoJSON
-                        return {
+                        var geojson = {
                             "type": "Feature",
                             "properties": j,
                             "geometry": {
-                                "type": "Point",
-                                "coordinates": [
-                                    j.longitude, j.latitude
-                                ]
-                            }
+                                "type": "GeometryCollection",
+                                "geometries": [{
+                                    "type": "Point",
+                                    "coordinates": [j.longitude, j.latitude]},
+                                    {
+                                    "type": "MultiLineString",
+                                    "coordinates": i.geometry.coordinates[1]}
+                                ]}
                         };
+                        return geojson;
                     }).value();
                 // Update the event set.
                 self.events.features.length = 0;
@@ -245,7 +249,8 @@ module.controller("BayNetController", function($scope, $log, stations, station_c
         "available_authors": [],
         "selected_authors": [],
         "show_public_and_private": true,
-        "show_automatic_and_manual": true
+        "show_automatic_and_manual": true,
+        "show_uncertainties": true,
     };
 
     $scope.station_settings = {


### PR DESCRIPTION
This PR enables plotting of origin horizontal uncertainties in the WebGIS as hairlines:

![pr](https://user-images.githubusercontent.com/1842780/30704723-d8e0d05e-9ef3-11e7-8f0b-4bc75f785dd9.png)




This consists of changes in multiple places:
 - during QuakeML document  #indexing
    - horizontal uncertainties are parsed and added to the indexes
    - django geometry field now is a list of a Point and a MultiLineString (which is empty in case of no uncertainties given)
    - to calculate the end points of the error bar lines, package `geopy` is added as a new dependency (it's available on current Debian stable through packaging and also in conda, so no big deal) to do the Vincenty calculations
 - in the WebGIS adds a switch to turn on/off uncertainty plotting (as it can be quite a haystack for big event clusters)

These changes can be added to existing live Jane instances without problems, I think. Only a reindexing of all events will be necessary.

I confirmed that it (still) works for Events that don't have an Origin, or have an Origin without uncertainty information