### PR TITLE
add option to use django-request for detailed logging of all requests

### DIFF
--- a/src/jane/local_settings.py.example
+++ b/src/jane/local_settings.py.example
@@ -93,6 +93,52 @@ JANE_ACCENT_COLOR = "#D9230F"
 JANE_FDSN_STATIONXML_SENDER = "Jane"
 JANE_FDSN_STATIONXML_SOURCE = "Jane"
 
+###############################################################################
+# Additional Apps / Middleware
+###############################################################################
+ADDITIONAL_INSTALLED_APPS = []
+# ADDITIONAL_MIDDLEWARE_CLASSES is a dictionary with the name of the class as
+# key and potentially values 'before' and 'after' that can be lists of other
+# classes.
+ADDITIONAL_MIDDLEWARE_CLASSES = {}
+##################
+# django-request for user statistics
+##################
+# Uncomment the following to use django-request to log all requests including
+# originating user into jane's database. Ideally this should be uncommented
+# before the initial jane setup (specifically django's migration step).
+# Install `django-request` Python module beforehand.
+# XXX ADDITIONAL_INSTALLED_APPS += ['request']
+# From django-request docs:
+# (https://django-request.readthedocs.io/en/latest/index.html#first-steps)
+# If you use django.contrib.auth.middleware.AuthenticationMiddleware,
+# place RequestMiddleware after it.
+# If you use django.contrib.flatpages.middleware.FlatpageFallbackMiddleware
+# place request.middleware.RequestMiddleware before it else flatpages will
+# be marked as error pages in the admin panel.
+# XXX ADDITIONAL_MIDDLEWARE_CLASSES['request.middleware.RequestMiddleware'] = {
+# XXX     'after': ['django.contrib.auth.middleware.AuthenticationMiddleware'],
+# XXX     'before': [
+# XXX         'django.contrib.flatpages.middleware.FlatpageFallbackMiddleware']}
+# XXX REQUEST_TRAFFIC_MODULES = (
+# XXX     'request.traffic.User',
+# XXX     'request.traffic.UniqueVisitor',
+# XXX     'request.traffic.UniqueVisit',
+# XXX     'request.traffic.Hit',
+# XXX     'request.traffic.Error404',
+# XXX     'request.traffic.Error',
+# XXX     )
+# XXX REQUEST_PLUGINS = (
+# XXX     'request.plugins.TrafficInformation',
+# XXX     'request.plugins.LatestRequests',
+# XXX     'request.plugins.TopPaths',
+# XXX     'request.plugins.TopErrorPaths',
+# XXX     'request.plugins.TopReferrers',
+# XXX     'request.plugins.TopSearchPhrases',
+# XXX     'request.plugins.TopBrowsers',
+# XXX     'request.plugins.LatestRequests',
+# XXX     )
+##################
 
 # Change the settings for the test database here!
 if 'test' in sys.argv:

--- a/src/jane/settings.py
+++ b/src/jane/settings.py
@@ -288,11 +288,39 @@ JANE_FDSN_STATIONXML_SOURCE = "Jane"
 ###############################################################################
 try:
     from .local_settings import *  # NOQA @UnusedWildImport
+    from .local_settings import (
+        ADDITIONAL_INSTALLED_APPS, ADDITIONAL_MIDDLEWARE_CLASSES)
 except ImportError:
     print("ERROR: You need to copy local_settings.py.example into " +
           "local_settings.py and edit its content before running this "
           "service.")
     exit()
+# add additional apps from local_settings, if any
+INSTALLED_APPS.extend(ADDITIONAL_INSTALLED_APPS)
+for name, placement in ADDITIONAL_MIDDLEWARE_CLASSES.items():
+    before = placement.get('before', [])
+    after = placement.get('after', [])
+    before_index = len(MIDDLEWARE_CLASSES)
+    after_index = -1
+    # try to find the mentioned classes in the middleware and determine where
+    # the additional middleware should be inserted
+    # searching through list: https://stackoverflow.com/a/9542768
+    for name_ in before:
+        before_index = min(
+            next((i for i, item in enumerate(MIDDLEWARE_CLASSES)
+                  if item == name_), before_index),
+            before_index)
+    for name_ in after:
+        after_index = max(
+            next((i for i, item in enumerate(MIDDLEWARE_CLASSES)
+                  if item == name_), after_index),
+            after_index)
+    if before_index <= after_index:
+        msg = ("Can not insert additional middleware class '{}' from "
+               "local_settings.py because before/after constraints can not "
+               "be satisfied.").format(name)
+        raise Exception(msg)
+    MIDDLEWARE_CLASSES.insert(before_index, name)
 
 
 # speed up tests


### PR DESCRIPTION
This adds a ways of adding additional apps and middleware through `local_settings.py`, also being able to control position of additional middleware in the chain.

`django-request` is commented by default, so deactivated but can be switched on in `local_settings.py`.

Tested it locally, works when activated before initial jane setup (before intial migrations).

Closes #41