### PR TITLE
fix magnitude slider, precision setting

### DIFF
--- a/src/jane/static/web_gis/index.html
+++ b/src/jane/static/web_gis/index.html
@@ -139,7 +139,7 @@
                         ng-model="event_settings.magnitude_range"
                         min="-5"
                         step="0.5"
-                        precision="0.1"
+                        precision="1"
                         max="10"
                         data-slider-tooltip="hide"
                         value="{{ event_settings.magnitude_range }}">


### PR DESCRIPTION
precision has to be specified as number of digits, e.g. "1" for accuracy
to 1/10 of a magnitude step.

See
https://github.com/seiyria/bootstrap-slider/blob/master/README.md#options

```
precision

float

number of digits after the decimal of step value

The number of digits shown after the decimal. Defaults to the number of
digits after the decimal of step value.
```