### PR TITLE
Event modal fixes

### DIFF
--- a/src/jane/static/web_gis/src/baynetapp.js
+++ b/src/jane/static/web_gis/src/baynetapp.js
@@ -58,7 +58,6 @@ module.factory('events', function($http, $log, jane_server) {
                             return false;
                         }
                         if (i.indexed_data.magnitude === null) {
-                            i.indexed_data.magnitude = 1.0;
                             // Add flag that this magnitude is fake.
                             i.indexed_data.has_no_magnitude = true;
                         }

--- a/src/jane/static/web_gis/templates/event_modal.tpl.html
+++ b/src/jane/static/web_gis/templates/event_modal.tpl.html
@@ -22,7 +22,7 @@
                           <dt>Magnitude</dt>
                           <dd>{{ magnitude_type }} {{ magnitude | number:1 }}</dd>
                           <dt>Origin Time</dt>
-                          <dd>{{ origin_time | date:medium}}</dd>
+                          <dd>{{ origin_time | date:"yyyy-MM-dd HH:mm:ss Z" }}</dd>
                           <dt>Event Type</dt>
                           <dd>{{ event_type }}</dd>
                           <dt>Evaluation Mode</dt>


### PR DESCRIPTION
This PR has two fixes for the event modal:

 - fixes null-valued magnitudes, which currently get displayed as "Magnitude: 1"
 - fixes origin time display, it was only showing the date so far (also adds time zone specifier as the time zone can not be forced to UTC in angular <1.3)