### PR TITLE
Allow reading/indexing of GSE2 files with bad checksum

### DIFF
--- a/src/jane/waveforms/process_waveforms.py
+++ b/src/jane/waveforms/process_waveforms.py
@@ -50,7 +50,7 @@ def process_file(filename):
     # Step 2: Read the file and perform a couple of sanity checks. Delete an
     #         eventually existing file.
     try:
-        stream = read(filename)
+        stream = read(filename, verify_chksum=False)
     except:
         # Delete if invalid file.
         if file is not None:


### PR DESCRIPTION
Quite a lot of old GSE2 files have invalid checksums, supposedly due to some bugs in old writing routines from back in the day. Probably we should just ignore those checksum problems. Due to the amount of valid GSE2 files with bad checksums these checksum tests seem more harmful than doing much good it seems.

CC @jwassermann 